### PR TITLE
Changed the threshold computation in the rhf filter in assim_tools to…

### DIFF
--- a/models/lorenz_96_tracer_advection/work/input.nml
+++ b/models/lorenz_96_tracer_advection/work/input.nml
@@ -85,7 +85,7 @@
    /
 
 &quantile_distributions_nml
-   fix_bound_violations = .true.,
+   fix_rh_bound_violations = .true.,
    use_logit_instead_of_probit = .true.
    do_inverse_check = .true.
    /


### PR DESCRIPTION
… be the

same as the one used in the RH transformation in quantile_distributions_mod. Added a check to the truncated_normal_like to deal with the possibility of a zero observational error variance.
Added temporary null likelihood test of the rhf increments to make sure that the distribution there is stable; it kills execution if violated. Modified the threshold computation for the RH transformation to allow the possibility of roundoff error.
Changed the name of the namelist parameter that controls fixing of bounds violations to note that it is only applied to the bounded_normal_rh. Added a function to do bounds fixing when the namelist is true. Added bounds correction to both parts of the to_probit_bounded_rh subroutine.

All tests, all cases, all ensemble sizes work for the L96 tracer with these settings.

## Description:
<!--- Describe your changes -->
Please provide a summary of the change and include any relevant motivation and context. 

### Fixes issue
<!--- link to github issue(s) -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
